### PR TITLE
Refactor movement physics

### DIFF
--- a/Includes/Helpers.hpp
+++ b/Includes/Helpers.hpp
@@ -12,6 +12,8 @@
 #include "Helpers/Wrappers.hpp"
 
 #include "Helpers/DataHelpers/Address.hpp"
+#include "Helpers/DataHelpers/Collision.hpp"
+#include "Helpers/DataHelpers/Control.hpp"
 #include "Helpers/DataHelpers/GameData.hpp"
 #include "Helpers/DataHelpers/Level.hpp"
 #include "Helpers/DataHelpers/Material.hpp"

--- a/Includes/Helpers/DataHelpers/Collision.hpp
+++ b/Includes/Helpers/DataHelpers/Collision.hpp
@@ -1,0 +1,22 @@
+#ifndef COLLISION_HPP
+#define COLLISION_HPP
+
+#include "CTRPluginFramework.hpp"
+
+namespace CTRPluginFramework {
+	class Collision {
+	public:
+		Collision(u16 ID, std::string colType);
+
+        static const Collision colList[];
+
+        static u16 colIDFromName(std::string name); 
+        static u16 getCurrCol(int player); 
+        static void setCurrCol(int player, u16 targetCol); 
+
+	private:
+		u16				_ID;
+		std::string		_colType;
+    };
+}
+#endif

--- a/Includes/Main/Gameplay.hpp
+++ b/Includes/Main/Gameplay.hpp
@@ -7,26 +7,33 @@
 #include "Unicode.h"
 
 namespace CTRPluginFramework {
-    void manageEnemy(bool keepAlive);
     extern MenuEntry* physicsEditAutoG;
     extern MenuEntry* physicsEditAutoB;
     extern MenuEntry* physicsEditAutoR;
-    std::string physicsSelectMenu(int Link);
-    void writePhysicsChanges(int Link);
+    extern MenuEntry* physicsSelG;
+    extern MenuEntry* physicsSelB;
+    extern MenuEntry* physicsSelR;
+
     extern MenuEntry* moonJumpEntry;
     extern MenuEntry* flightEntry;
-    extern MenuEntry* doppelEnableAuto;
+
     extern MenuEntry* reWarp;
+    extern MenuEntry* doppelEnableAuto;
     extern MenuEntry* challengeEditAuto;
-    int chooseDrablandsStage();
+
     extern MenuEntry* controlAllAuto;
 
-    
+    std::string physicsSelectMenu(int Link);
+    void writePhysicsChanges(int player);
+
+    void manageEnemy(bool keepAlive);
+
     std::string warpSelLevel(StringVector locNames);
     int warpGetLevel(int locCategory);
     int warpGetStage(int levelID);
     int warpSelStage(StringVector stageNames);
     int warpSelChallenge(void);
+
     class Gameplay {
     public:
         static void infEnergy(MenuEntry* entry);
@@ -42,12 +49,9 @@ namespace CTRPluginFramework {
 
         static void controlAllPlayers(MenuEntry* entry);
 
-        static void changePhysicsG(MenuEntry* entry);
-        static void changePhysicsB(MenuEntry* entry);
-        static void changePhysicsR(MenuEntry* entry);
-        static void physicsChangeG(MenuEntry* entry);
-        static void physicsChangeB(MenuEntry* entry);
-        static void physicsChangeR(MenuEntry* entry);
+        static void changePhysics(MenuEntry* entry);
+        static void writePhysicsChanges(MenuEntry* entry);
+
         static void moonJump(MenuEntry* entry);
         static void flight(MenuEntry* entry);
         static void adjustAscentSpeed(MenuEntry* entry);

--- a/Sources/Helpers/DataHelpers/Collision.cpp
+++ b/Sources/Helpers/DataHelpers/Collision.cpp
@@ -1,0 +1,48 @@
+#include "Helpers.hpp"
+#include "AddressList.hpp"
+
+#include <CTRPluginFramework.hpp>
+
+namespace CTRPluginFramework 
+{
+	Collision::Collision(u16 ID, std::string colName) :
+		_ID(ID), _colType(colName)
+	{
+	}
+	
+	const Collision Collision::colList[8] = {
+		Collision(0xA, "Fall_plane"), 
+        Collision(0x121, "Ice"),   
+		Collision(0x167, "Lava"),   
+		Collision(0x187, "Water"),   
+		Collision(0xC1, "Quicksand_plane"),   
+		Collision(0xC7, "Quicksand_stream"),   
+		Collision(0x364, "Colored_platform"),   
+		Collision(0x1F, "Air")
+    };
+
+    u16 Collision::colIDFromName(std::string name) 
+	{
+		for (int iterator = 0; iterator < 10; ++iterator) 
+		{
+			if (colList[iterator]._colType == name) 
+				return colList[iterator]._ID;
+		}
+		return 0xFFFF; // wasn't found
+	}
+   
+    u16 Collision::getCurrCol(int player) 
+	{
+		u16 colID;
+        u32 addressOffset = player * GameData::playerAddressOffset;
+
+		Process::Read16(AddressList::CollisionCurrent.addr + addressOffset, colID);
+		return colID;
+	}
+
+    void Collision::setCurrCol(int player, u16 targetCol) 
+	{
+        u32 addressOffset = player * GameData::playerAddressOffset;
+		Process::Write16(AddressList::CollisionCurrent.addr + addressOffset, targetCol);
+	}
+}

--- a/Sources/PluginMain.cpp
+++ b/Sources/PluginMain.cpp
@@ -133,13 +133,37 @@ namespace CTRPluginFramework {
             Hotkey(Key::R | Key::B, "Make all spawned enemies invincible"),
         }));
 
-        *physics += new MenuEntry("Physics - Player 1 (Green): None", nullptr, Gameplay::changePhysicsG);
-        *physics += new MenuEntry("Physics - Player 2 (Blue): None", nullptr, Gameplay::changePhysicsB);
-        *physics += new MenuEntry("Physics - Player 3 (Red): None", nullptr, Gameplay::changePhysicsR);
+        /* ------------------------------ */
 
-        physicsEditAutoG = new MenuEntry("Write physics edit G (auto)", Gameplay::physicsChangeG);
-        physicsEditAutoB = new MenuEntry("Write physics edit B (auto)", Gameplay::physicsChangeB);
-        physicsEditAutoR = new MenuEntry("Write physics edit R (auto)", Gameplay::physicsChangeR);
+        physicsSelG = new MenuEntry("Player 1 (Green): Not edited", nullptr, Gameplay::changePhysics);
+        physicsSelB = new MenuEntry("Player 2 (Blue): Not edited", nullptr, Gameplay::changePhysics);
+        physicsSelR = new MenuEntry("Player 3 (Red): Not edited", nullptr, Gameplay::changePhysics);
+
+        physicsEditAutoG = new MenuEntry("Write physics edit G (auto)", Gameplay::writePhysicsChanges);
+        physicsEditAutoB = new MenuEntry("Write physics edit B (auto)", Gameplay::writePhysicsChanges);
+        physicsEditAutoR = new MenuEntry("Write physics edit R (auto)", Gameplay::writePhysicsChanges);
+        
+        MenuEntry* physicsSlots[6] = {
+            physicsEditAutoG,
+            physicsSelG,
+            physicsEditAutoB,
+            physicsSelB,
+            physicsEditAutoR,
+            physicsSelR
+        };
+
+        for (int iterator = 0; iterator < 6; ++iterator)
+        {
+            // assign ArgIDs for EditAuto and Sel -> green = 0, blue = 1, red = 2
+            // integer division always rounds up, so iterator / 2 should always result in 0-2 values
+            physicsSlots[iterator]->SetArg(reinterpret_cast<void*>(iterator / 2));  
+
+            // add the physicsSel entries to the menu
+            if (iterator % 2 == 1)
+                *physics += physicsSlots[iterator];
+        }
+
+        /* ------------------------------ */
 
         moonJumpEntry = (EntryWithHotkey(new MenuEntry("Enable Moon Jump", Gameplay::moonJump), {
             Hotkey(Key::CPadUp, "Move North"),


### PR DESCRIPTION
Duplicated code originally separated by player (Gameplay::changePhysicsG/B/R) has been merged into a single function. ArgIDs have been assigned to individual MenuEntries under PluginMain.cpp, which are later used as playerIDs that determine which player's physics status should be edited.

New Collision class has also been added.